### PR TITLE
Output DMLOG ROOT_BLOCK on validator boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,13 @@
 /solana-metrics/
 /solana-metrics.tar.bz2
 /target/
+/bin/
+
 
 **/*.rs.bk
 .cargo
+.crates.toml
+.crates2.json
 
 /config/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,9 @@
 /solana-metrics/
 /solana-metrics.tar.bz2
 /target/
-/bin/
-
 
 **/*.rs.bk
 .cargo
-.crates.toml
-.crates2.json
 
 /config/
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1216,6 +1216,10 @@ fn new_banks_from_ledger(
         );
         leader_schedule_cache.set_root(&bank_forks.root_bank());
 
+        if deepmind_enabled() {
+            println!("DMLOG BLOCK_ROOT {}", bank_forks.root());
+        }
+
         let archive_file = solana_runtime::snapshot_utils::bank_to_snapshot_archive(
             ledger_path,
             &bank_forks.root_bank(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -413,9 +413,7 @@ impl Validator {
         if let Some(ref shrink_paths) = config.account_shrink_paths {
             bank.set_shrink_paths(shrink_paths.clone());
         }
-        if deepmind_enabled() {
-            println!("DMLOG BLOCK_ROOT {}", bank_forks.root());
-        }
+
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         let sample_performance_service =


### PR DESCRIPTION
#### Problem

We don't have a `DMLOG ROOT_BLOCK` on validator boot

#### Summary of Changes

Output `DMLOG ROOT_BLOCK` on validator boot

Resolves https://github.com/streamingfast/sf-solana/issues/47
